### PR TITLE
Add translations for "projekt0n/github-nvim-theme"

### DIFF
--- a/lua/ghostty-theme-sync/sync.lua
+++ b/lua/ghostty-theme-sync/sync.lua
@@ -106,18 +106,20 @@ function M.get_overlap()
 	local nvim_colorschemes = get_nvim_colorschemes()
 	local ghostty_colorschemes = get_ghostty_colorschemes()
 
-	local map = {}
+	-- Create a set of ghostty_colorschemes
+	local ghostty_colorschemes_set = {}
+	for _, value in ipairs(ghostty_colorschemes) do
+		ghostty_colorschemes_set[value] = true
+	end
+
 	local overlap = {}
 
 	for _, value in ipairs(nvim_colorschemes) do
 		-- Map nvim to ghostty in the table
 		local translated = translations.nvim_to_ghostty[value] or value
-		map[translated] = value
-	end
-
-	for _, value in ipairs(ghostty_colorschemes) do
-		if map[value] then
-			table.insert(overlap, map[value])
+		-- Check if ghostty has the colorscheme
+		if ghostty_colorschemes_set[translated] then
+			table.insert(overlap, value)
 		end
 	end
 

--- a/lua/ghostty-theme-sync/translations.lua
+++ b/lua/ghostty-theme-sync/translations.lua
@@ -5,6 +5,19 @@ local translations = {
 		["kanagawa-dragon"] = "Kanagawa Dragon",
 		["kanagawa-wave"] = "Kanagawa Wave",
 		["gruvbox"] = "GruvboxDark",
+
+		-- "projekt0n/github-nvim-theme",
+		["github_dark"] = "GitHub Dark",
+		["github_dark_colorblind"] = "GitHub Dark",
+		["github_dark_default"] = "GitHub Dark",
+		["github_dark_dimmed"] = "GitHub Dark",
+		["github_dark_high_contrast"] = "GitHub Dark",
+		["github_dark_tritanopia"] = "GitHub Dark",
+		["github_light"] = "Github",
+		["github_light_colorblind"] = "Github",
+		["github_light_default"] = "Github",
+		["github_light_high_contrast"] = "Github",
+		["github_light_tritanopia"] = "Github",
 	},
 }
 


### PR DESCRIPTION
## Description
Added translation mappings for [projekt0n/github-nvim-theme](https://github.com/projekt0n/github-nvim-theme) and optimized the overlap detection algorithm to support many-to-one theme mappings.

### Changes
1. Added github-nvim-theme mappings:
   - Dark variants mapping to "GitHub Dark":
     - `github_dark`
     - `github_dark_colorblind`
     - `github_dark_default`
     - `github_dark_dimmed`
     - `github_dark_high_contrast`
     - `github_dark_tritanopia`
   - Light variants mapping to "Github":
     - `github_light`
     - `github_light_colorblind`
     - `github_light_default`
     - `github_light_high_contrast`
     - `github_light_tritanopia`

2. Refactored overlap detection:
   - Changed from map-based to set-based lookup for better performance
   - Added support for multiple Neovim themes mapping to the same Ghostty theme
   - Simplified logic while maintaining functionality

### Testing
- Verified all github theme variants map correctly to their respective Ghostty themes
- Tested multiple Neovim themes mapping to same Ghostty theme (many-to-one)