### PR TITLE
fix: preserve whitespace on nvim config write

### DIFF
--- a/lua/ghostty-theme-sync/sync.lua
+++ b/lua/ghostty-theme-sync/sync.lua
@@ -25,8 +25,9 @@ local function persist_nvim_colorscheme(colorscheme)
 	-- Read in config and update colorscheme line
 	local lines = {}
 	for line in io.lines(path) do
-		if line:match("^%s*vim.cmd.colorscheme") then
-			table.insert(lines, "vim.cmd.colorscheme('" .. colorscheme .. "')")
+		local leading_whitespace = line:match("^(%s*)vim.cmd.colorscheme")
+		if leading_whitespace then
+			table.insert(lines, leading_whitespace .. "vim.cmd.colorscheme('" .. colorscheme .. "')")
 		else
 			table.insert(lines, line)
 		end


### PR DESCRIPTION
## Description
Fix whitespace preservation when updating colorscheme in Neovim config file

### Problem
When updating the colorscheme line in lua configuration, the existing indentation was being stripped, causing inconsistent formatting in the config file.

### Solution
- Capture leading whitespace using pattern matching before replacing the line
- Preserve the original indentation when writing the new colorscheme line
- Maintain user's formatting preferences in config file

### Changes
- Added whitespace capture in line matching pattern
- Apply captured whitespace to new colorscheme line
- Preserve original file formatting structure

### Example
Before:
```lua
{
	"projekt0n/github-nvim-theme",
	priority = 1000,
	config = function()
		vim.cmd.colorscheme("github_dark")
	end,
}
```